### PR TITLE
update: 電子書籍サービスの選択時の挙動を更新

### DIFF
--- a/app/lib/view/components/ebook_button.dart
+++ b/app/lib/view/components/ebook_button.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 
-class EbookButton extends StatelessWidget {
+class EbookButton extends HookWidget {
   final String label;
   final String imgSrc;
 
@@ -12,13 +13,25 @@ class EbookButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isSelected = useState<bool>(false);
     return 
       TextButton(
-        onPressed: () {},
-        child: SizedBox(
+        onPressed: () {
+          isSelected.value = !isSelected.value;
+        },
+        child: Container(
+           decoration: BoxDecoration(
+           border:  Border.all(
+              width: 2,
+              color: isSelected.value ? Colors.grey : Colors.black.withOpacity(0)
+              ), 
+            borderRadius: BorderRadius.circular(5) 
+          ), 
           width: 96,
           height: 96,
           child: Column(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
             children: [
               Image.asset(
                 imgSrc,

--- a/app/lib/view/components/ebooks.dart
+++ b/app/lib/view/components/ebooks.dart
@@ -2,13 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:app/view/components/ebook_button.dart';
 
 class Ebooks extends StatelessWidget {
-  
+
   const Ebooks({
     super.key, 
     });
 
   @override
   Widget build(BuildContext context) {
+
     return const Column(
       children: [
         Text(
@@ -20,7 +21,7 @@ class Ebooks extends StatelessWidget {
 
             EbookButton(
               label: 'まんがセゾン', 
-              imgSrc: 'assets/images/Sezon.jpg'
+              imgSrc: 'assets/images/Sezon.jpg',
             ),
             EbookButton(
               label: 'Kindle', 


### PR DESCRIPTION
ebook_buttonに状態管理useStateを持たせることで、選択時に選んだアイコンの枠線を表示させた。
ラジオボタンのような挙動には出来ておらず、複数選択を許容してしまっている。
registerにまとめるときに、うまくすり合わせてほしい。